### PR TITLE
Fix reconnect logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,14 @@ When sending a message indicating the recipients, the message sent to their queu
 ### Subscribe to broadcast messages by message type
 
 ```javascript
+  const logger = {
+    info: console.log,
+    warn: console.log,
+    error: console.error,
+  }
   const client = createClient({
     serviceName: 'news',
+    logger,
     connectOptions: {
       username: 'test',
       password: '123',

--- a/src/connection.spec.ts
+++ b/src/connection.spec.ts
@@ -37,16 +37,4 @@ Array [
 ]
 `);
   });
-
-  it('should fail if logger is empty', () => {
-    const optionsMock = {
-      connectOptions: {
-        username: 'stub',
-        password: 'test'
-      },
-      serviceName: 'test'
-    };
-
-    expect(() => connect(optionsMock)).toThrowError('logger is required.');
-  })
 });

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -12,10 +12,6 @@ export enum ConnectionStatus {
 const connect = (options: CreateServiceOptions): { service: ServiceConnection; connection: Promise<AMQPConnection> } => {
   const { connectOptions, serviceName } = options;
 
-  if (!options.logger) {
-    throw new Error('logger is required.');
-  }
-
   return connectServiceQueues(getAMQPNodeAdapter(), connectOptions, serviceName, options.logger);
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { MessageHandlerOptions, MessageHandler } from './message';
 export interface CreateServiceOptions {
   appId?: string;
   serviceName: string;
-  logger?: Logger;
+  logger: Logger;
   connectOptions: AMQPOptions;
 }
 


### PR DESCRIPTION
The handleConnectionClose may be called several times in short period of time.This may lead to several consumers is binded to one queue. We set synchronously the connection status to "connecting" and check it in the beginnig of the handler in order to fix the issue.